### PR TITLE
[New Card] NewRelic Server Response Time

### DIFF
--- a/index.json
+++ b/index.json
@@ -6,5 +6,9 @@
 	"AnalyticsCard": {
 		"repository": "https://github.com/charlesportwoodii/ciims-analytics-card",
 		"version": "0.0.1"
+	},
+	"NewRelicResponseTimeCard": {
+		"repository": "https://github.com/charlesportwoodii/ciims-newrelic-responsetime-card",
+		"version": "0.0.1"
 	}
 }


### PR DESCRIPTION
This card provides support to display NewRelic server response time on the dashboard. See https://github.com/charlesportwoodii/ciims-newrelic-responsetime-card

![card](https://cloud.githubusercontent.com/assets/630969/6473034/20976826-c1bc-11e4-901b-46635b8c64eb.png)
