### PR TITLE
[New Card] Github Repo Information

### DIFF
--- a/index.json
+++ b/index.json
@@ -3,6 +3,10 @@
 		"repository": "https://github.com/charlesportwoodii/ciims-analytics-card",
 		"version": "0.0.2"
 	},
+	"GithubCard": {
+		"repository": "https://github.com/charlesportwoodii/ciims-github-card",
+		"version": "0.0.1"
+	},
 	"NewRelicResponseTimeCard": {
 		"repository": "https://github.com/charlesportwoodii/ciims-newrelic-responsetime-card",
 		"version": "0.0.1"


### PR DESCRIPTION
A new dashboard card to display Github Repository information via the Github API

![screen shot 2015-04-30 at 1 45 07 pm](https://cloud.githubusercontent.com/assets/630969/7420082/24e4d872-ef3f-11e4-99a7-8c30d37eb6a2.png)
